### PR TITLE
Add ContentType enum and property and htmlBody 

### DIFF
--- a/src/emailmessage.cpp
+++ b/src/emailmessage.cpp
@@ -175,8 +175,13 @@ QString EmailMessage::fromDisplayName() const
 
 QString EmailMessage::htmlBody() const
 {
-    //TODO: reuse EmailMessageListModel::bodyHtmlText when moved
-    return QString();
+    // Fallback to plain message if no html body.
+    QMailMessagePartContainer *container = m_msg.findHtmlContainer();
+    if (contentType() == EmailMessage::HTML && container) {
+        return container->body().data();
+    } else {
+        return body();
+    }
 }
 
 QString EmailMessage::inReplyTo() const
@@ -288,12 +293,6 @@ void EmailMessage::setFrom(const QString &sender)
     }
     emit fromChanged();
     emit accountIdChanged();
-}
-
-void EmailMessage::setHtmlBody(const QString &htmlBody)
-{
-    // Signals are only emited when message is constructed
-    Q_UNUSED(htmlBody);
 }
 
 void EmailMessage::setInReplyTo(const QString &messageId)

--- a/src/emailmessage.h
+++ b/src/emailmessage.h
@@ -34,7 +34,7 @@ public:
     Q_PROPERTY(QString from READ from WRITE setFrom NOTIFY fromChanged)
     Q_PROPERTY(QString fromAddress READ fromAddress NOTIFY fromChanged)
     Q_PROPERTY(QString fromDisplayName READ fromDisplayName NOTIFY fromChanged)
-    Q_PROPERTY(QString htmlBody READ htmlBody WRITE setHtmlBody NOTIFY htmlBodyChanged)
+    Q_PROPERTY(QString htmlBody READ htmlBody NOTIFY htmlBodyChanged FINAL)
     Q_PROPERTY(QString inReplyTo READ inReplyTo WRITE setInReplyTo NOTIFY inReplyToChanged)
     Q_PROPERTY(int messageId READ messageId WRITE setMessageId NOTIFY messageIdChanged)
     Q_PROPERTY(int numberOfAttachments READ numberOfAttachments NOTIFY attachmentsChanged)
@@ -79,7 +79,6 @@ public:
     void setBody(const QString &body);
     void setCc(const QStringList &ccList);
     void setFrom(const QString &sender);
-    void setHtmlBody(const QString &htmlBody);
     void setInReplyTo(const QString &messageId);
     void setMessageId(int messageId);
     void setPriority(Priority priority);


### PR DESCRIPTION
For content type is should be enough to check just subType has it seems that "html" and "alternative" are valid html viewer requiring sub types. So, no need to check as "text/html" or "multipart/alternative". We could futher improve contentType to be read/write but currently I don't see use for that.

htmlBody is changed to read only property and fallbacking to body. Plain body also works for html viewers.
