### PR TITLE
[nemo-qml-plugin-email] Start messageserver as a detached process.

### DIFF
--- a/src/emailagent.h
+++ b/src/emailagent.h
@@ -79,6 +79,8 @@ signals:
 private slots:
     void activityChanged(QMailServiceAction::Activity activity);
     void attachmentDownloadActivityChanged(QMailServiceAction::Activity activity);
+    void onIpcConnectionEstablished();
+    void onMessageServerProcessError(QProcess::ProcessError error);
     void onStandardFoldersCreated(const QMailAccountId &accountId);
     void progressChanged(uint value, uint total);
 
@@ -89,6 +91,8 @@ private:
     bool m_transmitting;
     bool m_cancelling;
     bool m_synchronizing;
+    bool m_enqueing;
+    bool m_waitForIpc;
 
     QMailAccountIdList m_enabledAccounts;
 
@@ -99,7 +103,7 @@ private:
     QMailMessageId m_messageId;
     QMailMessagePart m_attachmentPart;
 
-    QProcess m_messageServerProcess;
+    QProcess* m_messageServerProcess;
 
     QList<QSharedPointer<EmailAction> > m_actionQueue;
     QSharedPointer<EmailAction> m_currentAction;

--- a/src/emailmessagelistmodel.cpp
+++ b/src/emailmessagelistmodel.cpp
@@ -83,8 +83,6 @@ EmailMessageListModel::EmailMessageListModel(QObject *parent)
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     setRoleNames(roles);
 #endif
-
-    EmailAgent::instance()->initMailServer();
     m_mailAccountIds = QMailStore::instance()->queryAccounts(
             QMailAccountKey::status(QMailAccount::Enabled, QMailDataComparator::Includes),
             QMailAccountSortKey::name());

--- a/src/emailmessagelistmodel.h
+++ b/src/emailmessagelistmodel.h
@@ -141,7 +141,6 @@ private:
     bool m_filterUnread;
     QProcess m_msgAccount;
     QMailFolderId m_currentFolderId;
-    QProcess m_messageServerProcess;
     QMailAccountIdList m_mailAccountIds;
     QMailRetrievalAction *m_retrievalAction;
     QString m_search;


### PR DESCRIPTION
- Enqueue all grouped services actions before start executing.

When messageserver is not running start it as a detached process,
many clients can connect to the daemon, starting the daemon as a child process can
cause problems when external process is using the daemon and it get's destructed
by this plugin.
Messageserver lifespan should be controlled by a system process manager(systemd or similar),
but in some cases it might not be running, e.g no e-mail accounts configured in the system.
