### PR TITLE
Emit sync changed signal when there's no enabled accounts and accountsSync is requested.

### DIFF
--- a/src/emailagent.cpp
+++ b/src/emailagent.cpp
@@ -175,7 +175,7 @@ void EmailAgent::activityChanged(QMailServiceAction::Activity activity)
         // don't try to synchronise extra accounts if the user cancelled the sync
         if (m_cancelling) {
             m_synchronizing = false;
-            emit synchronizingChanged();
+            emit synchronizingChanged(EmailAgent::Error);
             m_transmitting = false;
             m_cancelling = false;
             m_actionQueue.clear();
@@ -197,7 +197,7 @@ void EmailAgent::activityChanged(QMailServiceAction::Activity activity)
             if (m_currentAction.isNull()) {
                 qDebug() << "Sync completed with Errors!!!.";
                 m_synchronizing = false;
-                emit synchronizingChanged();
+                emit synchronizingChanged(EmailAgent::Error);
             }
             else {
                 executeCurrent();
@@ -231,7 +231,7 @@ void EmailAgent::activityChanged(QMailServiceAction::Activity activity)
         if (m_currentAction.isNull()) {
             qDebug() << "Sync completed.";
             m_synchronizing = false;
-            emit synchronizingChanged();
+            emit synchronizingChanged(EmailAgent::Completed);
         }
         else {
             executeCurrent();
@@ -324,7 +324,8 @@ void EmailAgent::accountsSync(const bool syncOnlyInbox, const uint minimum)
 
     if (m_enabledAccounts.isEmpty()) {
         qDebug() << Q_FUNC_INFO << "No enabled accounts, nothing to do.";
-        emit synchronizingChanged();
+        m_synchronizing = false;
+        emit synchronizingChanged(EmailAgent::Error);
         return;
     } else {
         foreach (QMailAccountId accountId, m_enabledAccounts) {
@@ -489,7 +490,7 @@ QString EmailAgent::signatureForAccount(int accountId)
     return QString();
 }
 
-int EmailAgent::standardFolderId(int accountId, QMailFolder::StandardFolder folder)
+int EmailAgent::standardFolderId(int accountId, QMailFolder::StandardFolder folder) const
 {
     QMailAccountId acctId(accountId);
     if (acctId.isValid()) {
@@ -745,7 +746,7 @@ void EmailAgent::executeCurrent()
 
         if (!m_synchronizing) {
             m_synchronizing = true;
-            emit synchronizingChanged();
+            emit synchronizingChanged(EmailAgent::Synchronizing);
         }
 
         //add network checks here.

--- a/src/emailagent.h
+++ b/src/emailagent.h
@@ -21,7 +21,7 @@
 class Q_DECL_EXPORT EmailAgent : public QObject
 {
     Q_OBJECT
-
+    Q_ENUMS(Status)
 public:
     static EmailAgent *instance();
 
@@ -29,6 +29,12 @@ public:
     ~EmailAgent();
 
     Q_PROPERTY(bool synchronizing READ synchronizing NOTIFY synchronizingChanged)
+
+    enum Status {
+        Synchronizing = 0,
+        Completed,
+        Error
+    };
 
     QString bodyPlainText(const QMailMessage &mailMsg) const;
     void exportUpdates(const QMailAccountId accountId);
@@ -39,7 +45,7 @@ public:
     quint64 newAction();
     void sendMessages(const QMailAccountId &accountId);
     void setupAccountFlags();
-    int standardFolderId(int accountId, QMailFolder::StandardFolder folder);
+    int standardFolderId(int accountId, QMailFolder::StandardFolder folder) const;
 
     Q_INVOKABLE void accountsSync(const bool syncOnlyInbox = false, const uint minimum = 20);
     Q_INVOKABLE void cancelSync();
@@ -74,7 +80,7 @@ signals:
     void progressUpdate(int percent);
     void sendCompleted();
     void standardFoldersCreated(const QMailAccountId &accountId);
-    void synchronizingChanged();
+    void synchronizingChanged(Status status);
 
 private slots:
     void activityChanged(QMailServiceAction::Activity activity);


### PR DESCRIPTION
EmailAgent::accountsSync(..) can be called when there's no accounts in device,
in this case the function should exit properly and let the client know that no
sync will be performed.
