### PR TITLE
[nemo-qml-plugin-email] Modified message body to behave as proper QML pr...

### DIFF
--- a/src/emailmessage.cpp
+++ b/src/emailmessage.cpp
@@ -131,7 +131,7 @@ QStringList EmailMessage::bcc() const
 
 QString EmailMessage::body() const
 {
-    return EmailAgent::instance()->bodyPlainText(m_msg);
+    return m_bodyText;
 }
 
 QStringList EmailMessage::cc() const
@@ -266,8 +266,10 @@ void EmailMessage::setBcc(const QStringList &bccList)
 
 void EmailMessage::setBody(const QString &body)
 {
-    // Signals are only emited when message is constructed
-    m_bodyText = body;
+    if (m_bodyText != body) {
+        m_bodyText = body;
+        emit bodyChanged();
+    }
 }
 
 void EmailMessage::setCc(const QStringList &ccList)
@@ -312,6 +314,7 @@ void EmailMessage::setMessageId(int messageId)
             m_msg = QMailMessage();
             qWarning() << "Invalid message id " << msgId.toULongLong();
         }
+        m_bodyText = EmailAgent::instance()->bodyPlainText(m_msg);
 
         // Message loaded from the store (or a empty message), all properties changes
         emit accountIdChanged();
@@ -321,6 +324,7 @@ void EmailMessage::setMessageId(int messageId)
         emit dateChanged();
         emit fromChanged();
         emit htmlBodyChanged();
+        emit bodyChanged();
         emit inReplyToChanged();
         emit messageIdChanged();
         emit priorityChanged();

--- a/src/emailmessage.h
+++ b/src/emailmessage.h
@@ -27,7 +27,7 @@ public:
     Q_PROPERTY(int accountId READ accountId NOTIFY accountIdChanged)
     Q_PROPERTY(QStringList attachments READ attachments WRITE setAttachments NOTIFY attachmentsChanged)
     Q_PROPERTY(QStringList bcc READ bcc WRITE setBcc NOTIFY bccChanged)
-    Q_PROPERTY(QString body READ body WRITE setBody NOTIFY storedMessageChanged)
+    Q_PROPERTY(QString body READ body WRITE setBody NOTIFY bodyChanged)
     Q_PROPERTY(QStringList cc READ cc WRITE setCc NOTIFY ccChanged)
     Q_PROPERTY(ContentType contentType READ contentType NOTIFY storedMessageChanged FINAL)
     Q_PROPERTY(QDateTime date READ date NOTIFY storedMessageChanged)
@@ -110,6 +110,7 @@ signals:
     void subjectChanged();
     void storedMessageChanged();
     void toChanged();
+    void bodyChanged();
 
 private slots:
     void onSendCompleted();


### PR DESCRIPTION
...operty

Consider following type of scenario:

Item { 
    id: emailComposer
    property alias emailBody: message.body

```
TextArea {
    id: textArea 
}

EmailMessage {
    id: message
}

Component.onCompleted: {
    textArea.text = message.body
}
```

}

One would expect that anything initially stored to emailComposer.emailBody
will end up to textArea.text but that's not the case with current EmailMessage
implementation. Modified EmailMessage to actually report changes in "body"
property. Do you see any problems in this approach?
