### PR TITLE
[nemo-qml-plugin-email] Add function to sync an account list.

### DIFF
--- a/rpm/nemo-qml-plugin-email-qt5.spec
+++ b/rpm/nemo-qml-plugin-email-qt5.spec
@@ -9,7 +9,7 @@ Name:       nemo-qml-plugin-email-qt5
 # << macros
 
 Summary:    Email plugin for Nemo Mobile
-Version:    0.1.6
+Version:    0.1.7
 Release:    1
 Group:      System/Libraries
 License:    BSD

--- a/src/emailagent.cpp
+++ b/src/emailagent.cpp
@@ -758,6 +758,25 @@ void EmailAgent::synchronizeInbox(int accountId, const uint minimum)
     }
 }
 
+//Sync accounts list (both ways)
+void EmailAgent::syncAccounts(const QMailAccountIdList &accountIdList, const bool syncOnlyInbox, const uint minimum)
+{
+    if (accountIdList.isEmpty()) {
+        qDebug() << Q_FUNC_INFO << "No enabled accounts, nothing to do.";
+        emit synchronizingChanged(EmailAgent::Error);
+        return;
+    } else {
+        foreach (QMailAccountId accountId, accountIdList) {
+            if (syncOnlyInbox) {
+                synchronizeInbox(accountId.toULongLong(), minimum);
+            }
+            else {
+                enqueue(new Synchronize(m_retrievalAction.data(), accountId));
+            }
+        }
+    }
+}
+
 // ############## Private API #########################
 
 bool EmailAgent::actionInQueue(QSharedPointer<EmailAction> action) const

--- a/src/emailagent.h
+++ b/src/emailagent.h
@@ -66,6 +66,7 @@ public:
     void sendMessages(const QMailAccountId &accountId);
     void setupAccountFlags();
     int standardFolderId(int accountId, QMailFolder::StandardFolder folder) const;
+    void syncAccounts(const QMailAccountIdList &accountIdList, const bool syncOnlyInbox = true, const uint minimum = 20);
 
     Q_INVOKABLE void accountsSync(const bool syncOnlyInbox = false, const uint minimum = 20);
     Q_INVOKABLE void cancelSync();


### PR DESCRIPTION
void EmailAgent::syncAccounts(const QMailAccountIdList &accountIdList, const bool syncOnlyInbox, const uint minimum)
