### PR TITLE
[nemo-qml-plugin-email] Improve standard folder handling for trash folder

### DIFF
--- a/src/emailagent.h
+++ b/src/emailagent.h
@@ -133,7 +133,7 @@ private:
     static EmailAgent *m_instance;
 
     uint m_actionCount;
-    uint m_accountSyncronizing;
+    uint m_accountSynchronizing;
     bool m_transmitting;
     bool m_cancelling;
     bool m_synchronizing;


### PR DESCRIPTION
Change default account sync to -1 since QMF can return 0 for invalid accounts.
