### PR TITLE
[nemo-qml-plugin-email] Use disconnected API for move messages.

### DIFF
--- a/rpm/nemo-qml-plugin-email-qt5.spec
+++ b/rpm/nemo-qml-plugin-email-qt5.spec
@@ -9,7 +9,7 @@ Name:       nemo-qml-plugin-email-qt5
 # << macros
 
 Summary:    Email plugin for Nemo Mobile
-Version:    0.1.26
+Version:    0.1.28
 Release:    1
 Group:      System/Libraries
 License:    BSD

--- a/src/emailaction.cpp
+++ b/src/emailaction.cpp
@@ -202,7 +202,7 @@ QMailServiceAction* FlagMessages::serviceAction() const
 */
 MoveToFolder::MoveToFolder(QMailStorageAction *storageAction, const QMailMessageIdList &ids,
                            const QMailFolderId &folderId)
-    : EmailAction(false)
+    : EmailAction()
     , _storageAction(storageAction)
     , _ids(ids)
     , _destinationFolder(folderId)
@@ -228,11 +228,11 @@ QMailServiceAction* MoveToFolder::serviceAction() const
 }
 
 /*
-  MoveToStandardFolder
+   MoveToStandardFolder
 */
 MoveToStandardFolder::MoveToStandardFolder(QMailStorageAction *storageAction,
                                            const QMailMessageIdList &ids, QMailFolder::StandardFolder standardFolder)
-    : EmailAction(false)
+    : EmailAction()
     , _storageAction(storageAction)
     , _ids(ids)
     , _standardFolder(standardFolder)

--- a/src/emailagent.cpp
+++ b/src/emailagent.cpp
@@ -237,9 +237,8 @@ void EmailAgent::moveMessages(const QMailMessageIdList &ids, const QMailFolderId
     QMailMessageId id(ids[0]);
     QMailAccountId accountId = accountForMessageId(id);
 
-    m_enqueing = true;
-    enqueue(new MoveToFolder(m_storageAction.data(), ids, destinationId));
-    m_enqueing = false;
+    QMailDisconnected::moveToFolder(ids, destinationId);
+
     enqueue(new ExportUpdates(m_retrievalAction.data(), accountId));
 }
 

--- a/src/emailmessagelistmodel.cpp
+++ b/src/emailmessagelistmodel.cpp
@@ -640,13 +640,9 @@ void EmailMessageListModel::moveSelectedMessageIds(int vFolderId)
     if (m_selectedMsgIds.empty())
         return;
 
-    QMailFolderId const id(vFolderId);
-
-    QMailMessage const msg(m_selectedMsgIds[0]);
-
+    const QMailFolderId id(vFolderId);
     EmailAgent::instance()->moveMessages(m_selectedMsgIds, id);
     m_selectedMsgIds.clear();
-    EmailAgent::instance()->exportUpdates(msg.parentAccountId());
 }
 
 void EmailMessageListModel::deleteSelectedMessageIds()


### PR DESCRIPTION
Fixes wrong state in the moveToFolder online actions.
