### PR TITLE
[nemo-qml-plugin-email] Cache unread count for accts and folders

### DIFF
--- a/src/emailaccountlistmodel.h
+++ b/src/emailaccountlistmodel.h
@@ -82,8 +82,12 @@ protected:
 
 private:
     QHash<int, QByteArray> roles;
+    QHash<QMailAccountId, int> m_unreadCountCache;
     QDateTime m_lastUpdateTime;
     bool m_canTransmitAccounts;
+
+    int accountUnreadCount(const QMailAccountId accountId);
+
 };
 
 #endif

--- a/src/folderlistmodel.h
+++ b/src/folderlistmodel.h
@@ -86,10 +86,12 @@ private:
         QMailFolderId folderId;
         FolderStandardType folderType;
         QMailMessageKey messageKey;
+        int unreadCount;
 
         FolderItem(QModelIndex idx, QMailFolderId mailFolderId,
-                   FolderStandardType mailFolderType, QMailMessageKey folderMessageKey) :
-            index(idx), folderId(mailFolderId), folderType(mailFolderType), messageKey(folderMessageKey) {}
+                   FolderStandardType mailFolderType, QMailMessageKey folderMessageKey, int folderUnreadCount) :
+            index(idx), folderId(mailFolderId), folderType(mailFolderType), messageKey(folderMessageKey),
+            unreadCount(folderUnreadCount) {}
     };
 
     int m_currentFolderIdx;


### PR DESCRIPTION
When there is large amount of messages DB queries can be expensive,
models that can be binded to UI elements need to provide fast response in order to
avoid UI freezes, this commit is a intermediate step, all DB calls should be moved
to a separated thread.
