### PR TITLE
[nemo-qml-plugin-email] Simplify add attachments code.

### DIFF
--- a/rpm/nemo-qml-plugin-email-qt5.spec
+++ b/rpm/nemo-qml-plugin-email-qt5.spec
@@ -9,7 +9,7 @@ Name:       nemo-qml-plugin-email-qt5
 # << macros
 
 Summary:    Email plugin for Nemo Mobile
-Version:    0.1.41
+Version:    0.1.42
 Release:    1
 Group:      System/Libraries
 License:    BSD

--- a/src/emailmessage.cpp
+++ b/src/emailmessage.cpp
@@ -733,31 +733,15 @@ void EmailMessage::emitMessageReloadedSignals()
 
 void EmailMessage::processAttachments()
 {
-    QMailMessagePart attachmentPart;
+    QStringList attachments;
     foreach (QString attachment, m_attachments) {
         // Attaching a file
-        if (attachment.startsWith("file://"))
+        if (attachment.startsWith("file://")) {
             attachment.remove(0, 7);
-        QFileInfo fi(attachment);
-
-        // Just in case..
-        if (!fi.isFile())
-            continue;
-
-        QMailMessageContentType attachmenttype(QMail::mimeTypeFromFileName(attachment).toLatin1());
-        attachmenttype.setName(fi.fileName().toLatin1());
-
-        QMailMessageContentDisposition disposition(QMailMessageContentDisposition::Attachment);
-        disposition.setFilename(fi.fileName().toLatin1());
-        disposition.setSize(fi.size());
-
-        attachmentPart = QMailMessagePart::fromFile(attachment,
-                                                    disposition,
-                                                    attachmenttype,
-                                                    QMailMessageBody::Base64,
-                                                    QMailMessageBody::RequiresEncoding);
-        m_msg.appendPart(attachmentPart);
+        }
+        attachments.append(attachment);
     }
+    m_msg.setAttachments(attachments);
 }
 
 void EmailMessage::requestMessageDownload()


### PR DESCRIPTION
Current implementation fails when the filename has no latin chars.
QMF implementation(addAttachmentsToMultipart) already handles this properly
encoding the name in utf-8 format.
