### PR TITLE
[nemo-qml-plugin-email] Improve drafts handling

### DIFF
--- a/src/emailagent.h
+++ b/src/emailagent.h
@@ -88,6 +88,7 @@ public:
     Q_INVOKABLE void deleteFolder(int folderId);
     Q_INVOKABLE void deleteMessage(int messageId);
     Q_INVOKABLE void deleteMessages(const QMailMessageIdList &ids);
+    Q_INVOKABLE void expungeMessages(const QMailMessageIdList &ids);
     Q_INVOKABLE void downloadAttachment(int messageId, const QString &attachmentlocation);
     Q_INVOKABLE void exportUpdates(int accountId);
     Q_INVOKABLE void getMoreMessages(int folderId, uint minimum = 20);

--- a/src/emailmessage.h
+++ b/src/emailmessage.h
@@ -166,6 +166,7 @@ private:
     QString m_bodyText;
     QMailMessageId m_id;
     QMailMessageId m_originalMessageId;
+    QMailMessageId m_idToRemove;
     QMailMessage m_msg;
     bool m_newMessage;
     quint64 m_downloadActionId;


### PR DESCRIPTION
Some services(e.g gmail, outlook) automatically create emails in the
send folder when using their smtp and if after sending the imap client
does not append a email to the same folder.
When sending a draft that exists in the server side,
if we copy the existent email to the send folder it will cause a duplicate
due to the automatic creation by the server, with this commit we always create
new emails from existent drafts and then delete the drafts after enqueing them for
sending.
