### PR TITLE
[MessageList] Add unreadMailsSelected property.

### DIFF
--- a/src/emailagent.cpp
+++ b/src/emailagent.cpp
@@ -259,6 +259,14 @@ void EmailAgent::sendMessages(const QMailAccountId &accountId)
     }
 }
 
+void EmailAgent::setMessagesReadState(const QMailMessageIdList &ids, bool state)
+{
+    Q_ASSERT(!ids.empty());
+    QMailMessageId msgId(ids[0]);
+    QMailStore::instance()->updateMessagesMetaData(QMailMessageKey::id(ids), QMailMessage::Read, state);
+    enqueue(new ExportUpdates(m_retrievalAction.data(), accountForMessageId(msgId)));
+}
+
 void EmailAgent::setupAccountFlags()
 {
     if (!QMailStore::instance()->accountStatusMask("StandardFoldersRetrieved")) {

--- a/src/emailagent.h
+++ b/src/emailagent.h
@@ -83,6 +83,8 @@ public:
     void moveMessages(const QMailMessageIdList &ids, const QMailFolderId &destinationId);
     void sendMessage(const QMailMessageId &messageId);
     void sendMessages(const QMailAccountId &accountId);
+    void setMessagesReadState(const QMailMessageIdList &ids, bool state);
+
     void setupAccountFlags();
     int standardFolderId(int accountId, QMailFolder::StandardFolder folder) const;
     void syncAccounts(const QMailAccountIdList &accountIdList, const bool syncOnlyInbox = true, const uint minimum = 20);

--- a/src/emailmessagelistmodel.cpp
+++ b/src/emailmessagelistmodel.cpp
@@ -414,6 +414,11 @@ EmailMessageListModel::Sort EmailMessageListModel::sortBy() const
     return m_sortBy;
 }
 
+bool EmailMessageListModel::unreadMailsSelected() const
+{
+    return !m_selectedUnreadIdx.isEmpty();
+}
+
 void EmailMessageListModel::sortBySender(int order)
 {
     sortByTime(order, Sender);
@@ -664,6 +669,13 @@ void EmailMessageListModel::selectMessage(int idx)
         m_selectedMsgIds.append(msgId);
         dataChanged(index(idx), index(idx));
     }
+
+    if (m_selectedUnreadIdx.isEmpty() && !messageRead(idx)) {
+        m_selectedUnreadIdx.append(idx);
+        emit unreadMailsSelectedChanged();
+    } else if (!messageRead(idx)) {
+        m_selectedUnreadIdx.append(idx);
+    }
 }
 
 void EmailMessageListModel::deSelectMessage(int idx)
@@ -673,6 +685,13 @@ void EmailMessageListModel::deSelectMessage(int idx)
     if (m_selectedMsgIds.contains (msgId)) {
         m_selectedMsgIds.removeOne(msgId);
         dataChanged(index(idx), index(idx));
+    }
+
+    if (m_selectedUnreadIdx.contains(idx)) {
+        m_selectedUnreadIdx.removeOne(idx);
+        if (m_selectedUnreadIdx.isEmpty()) {
+            emit unreadMailsSelectedChanged();
+        }
     }
 }
 

--- a/src/emailmessagelistmodel.h
+++ b/src/emailmessagelistmodel.h
@@ -31,6 +31,7 @@ class Q_DECL_EXPORT EmailMessageListModel : public QMailMessageListModel
     Q_PROPERTY(bool filterUnread READ filterUnread WRITE setFilterUnread NOTIFY filterUnreadChanged)
     Q_PROPERTY(uint limit READ limit WRITE setLimit NOTIFY limitChanged)
     Q_PROPERTY(EmailMessageListModel::Sort sortBy READ sortBy NOTIFY sortByChanged)
+    Q_PROPERTY(bool unreadMailsSelected READ unreadMailsSelected NOTIFY unreadMailsSelectedChanged FINAL)
 
 public:
     enum Roles
@@ -82,6 +83,7 @@ public:
     void setLimit(uint limit);
     void setFilterUnread(bool u);
     EmailMessageListModel::Sort sortBy() const;
+    bool unreadMailsSelected() const;
 
 Q_SIGNALS:
     void canFetchMoreChanged();
@@ -90,6 +92,7 @@ Q_SIGNALS:
     void filterUnreadChanged();
     void limitChanged();
     void sortByChanged();
+    void unreadMailsSelectedChanged();
 
 signals:
     void messageDownloadCompleted();
@@ -164,6 +167,7 @@ private:
     QMailMessageSortKey m_sortKey;
     EmailMessageListModel::Sort m_sortBy;
     QList<QMailMessageId> m_selectedMsgIds;
+    QList<int> m_selectedUnreadIdx;
 
     void checkFetchMoreChanged();
 };

--- a/src/emailmessagelistmodel.h
+++ b/src/emailmessagelistmodel.h
@@ -140,6 +140,8 @@ public slots:
     Q_INVOKABLE void deSelectMessage(int index);
     Q_INVOKABLE void moveSelectedMessageIds(int vFolderId);
     Q_INVOKABLE void deleteSelectedMessageIds();
+    Q_INVOKABLE void markAsReadSelectedMessagesIds();
+    Q_INVOKABLE void markAsUnReadSelectedMessagesIds();
     Q_INVOKABLE void markAllMessagesAsRead();
 
     void foldersAdded(const QMailFolderIdList &folderIds);
@@ -166,7 +168,7 @@ private:
     QMailMessageKey m_key;                  // key set externally other than search
     QMailMessageSortKey m_sortKey;
     EmailMessageListModel::Sort m_sortBy;
-    QList<QMailMessageId> m_selectedMsgIds;
+    QMap<int, QMailMessageId> m_selectedMsgIds;
     QList<int> m_selectedUnreadIdx;
 
     void checkFetchMoreChanged();


### PR DESCRIPTION
unreadMailsSelected property is true when one unread email is selected
this property can be used by clients to alternate read/unread buttons/menus
when in multi selection mode.