### PR TITLE
[accounts] Reload QMailAccountConfiguration when accountId changes and after initial check.

### DIFF
--- a/src/emailaccount.cpp
+++ b/src/emailaccount.cpp
@@ -288,6 +288,7 @@ void EmailAccount::setAccountId(const int accId)
     QMailAccountId accountId(accId);
     if (accountId.isValid()) {
         mAccount = new QMailAccount(accountId);
+        mAccountConfig = new QMailAccountConfiguration(mAccount->id());
     }
     else {
         qCWarning(lcGeneral) << "Invalid account id " << accountId.toULongLong();
@@ -426,11 +427,12 @@ void EmailAccount::setRecvPassword(QString val)
     mRecvCfg->setValue("password", Base64::encode(val));
 }
 
-bool EmailAccount::pushCapable() const
+bool EmailAccount::pushCapable()
 {
     if (mRecvType.toLower() == "imap4") {
         // Reload configuration since this setting is saved by messageserver
-        QMailServiceConfiguration imapConf(mAccountConfig, mRecvType);
+        mAccountConfig = new QMailAccountConfiguration(mAccount->id());
+        QMailServiceConfiguration imapConf(mAccountConfig, "imap4");
         return (imapConf.value("pushCapable").toInt() != 0);
     } else {
         return false;

--- a/src/emailaccount.h
+++ b/src/emailaccount.h
@@ -36,7 +36,7 @@ class Q_DECL_EXPORT EmailAccount : public QObject {
     Q_PROPERTY(QString recvSecurity READ recvSecurity WRITE setRecvSecurity)
     Q_PROPERTY(QString recvUsername READ recvUsername WRITE setRecvUsername)
     Q_PROPERTY(QString recvPassword READ recvPassword WRITE setRecvPassword)
-    Q_PROPERTY(QString pushCapable READ pushCapable)
+    Q_PROPERTY(bool pushCapable READ pushCapable)
 
     Q_PROPERTY(QString sendServer READ sendServer WRITE setSendServer)
     Q_PROPERTY(QString sendPort READ sendPort WRITE setSendPort)
@@ -90,7 +90,7 @@ public:
     void setRecvUsername(QString val);
     QString recvPassword() const;
     void setRecvPassword(QString val);
-    bool pushCapable() const;
+    bool pushCapable();
 
     QString sendServer() const;
     void setSendServer(QString val);


### PR DESCRIPTION
After initial testing of accounts messageserver writes some properties to
accounts, we need to reload settings after that to load the new properties.