### PR TITLE
[messageModel] Introduce MessageParsedSubject role.

### DIFF
--- a/src/emailmessagelistmodel.cpp
+++ b/src/emailmessagelistmodel.cpp
@@ -96,6 +96,7 @@ EmailMessageListModel::EmailMessageListModel(QObject *parent)
     roles[MessageSortByRole] = "sortBy";
     roles[MessageSubjectFirstCharRole] = "subjectFirstChar";
     roles[MessageSenderFirstCharRole] = "senderFirstChar";
+    roles[MessageParsedSubject] = "parsedSubject";
 
     m_key = key();
     m_sortKey = QMailMessageSortKey::timeStamp(Qt::DescendingOrder);
@@ -305,6 +306,13 @@ QVariant EmailMessageListModel::data(const QModelIndex & index, int role) const 
     else if (role == MessageSenderFirstCharRole) {
         QString sender = messageMetaData.from().name();
         return firstChar(sender);
+    } else if (role == MessageParsedSubject) {
+        // Filter <img> and <ahref> html tags to make the text suitable to be displayed in a qml
+        // label using StyledText(allows only small subset of html)
+        QString subject = data(index, QMailMessageModelBase::MessageSubjectTextRole).toString();
+        subject.replace(QRegExp("<\\s*img", Qt::CaseInsensitive), "<no-img");
+        subject.replace(QRegExp("<\\s*a", Qt::CaseInsensitive), "<no-a");
+        return subject;
     }
 
     return QMailMessageListModel::data(index, role);

--- a/src/emailmessagelistmodel.h
+++ b/src/emailmessagelistmodel.h
@@ -60,7 +60,8 @@ public:
         MessageFolderIdRole,                                   // returns parent folder id for the message
         MessageSortByRole,                                     // returns the sorting order of the list model
         MessageSubjectFirstCharRole,                           // returns the first character of the subject
-        MessageSenderFirstCharRole                             // returns the first character of the sender's display name
+        MessageSenderFirstCharRole,                            // returns the first character of the sender's display name
+        MessageParsedSubject                                   // returns the message subject parsed against a pre-defined regular expression
     };
 
     EmailMessageListModel(QObject *parent = 0);


### PR DESCRIPTION
MessageParsedSubject returns the email subject with 'disabled' html
tags <img> and <a href> making the text appropriated to use in a static
QML label with StyledText.