### PR TITLE
[attachments] Save temporary attachments inside a separated folder per account. Fixes JB#31268

### DIFF
--- a/src/attachmentlistmodel.cpp
+++ b/src/attachmentlistmodel.cpp
@@ -153,7 +153,11 @@ void AttachmentListModel::onAttachmentUrlChanged(const QString &attachmentLocati
 
 QString AttachmentListModel::attachmentUrl(const QMailMessage message, const QString &attachmentLocation)
 {
-    QString attachmentDownloadFolder = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation) + "/mail_attachments/" + attachmentLocation;
+    QMailAccountId accountId = message.parentAccountId();
+    // Temporary attachments must be saved in a account specific folder to enable easy cleaning of them
+    QString attachmentDownloadFolder = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation) + "/mail_attachments/"
+            + QString::number(accountId.toULongLong()) +  "/" + attachmentLocation;
+
     for (uint i = 0; i < message.partCount(); i++) {
         QMailMessagePart sourcePart = message.partAt(i);
         if (attachmentLocation == sourcePart.location().toString(true)) {

--- a/src/emailagent.cpp
+++ b/src/emailagent.cpp
@@ -1253,11 +1253,14 @@ void EmailAgent::removeAction(quint64 actionId)
 
 void EmailAgent::saveAttachmentToDownloads(const QMailMessageId messageId, const QString &attachmentLocation)
 {
-    QString attachmentDownloadFolder = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation) + "/mail_attachments/" + attachmentLocation;
     // Message and part structure can be updated during attachment download
     // is safer to reload everything
     const QMailMessage message (messageId);
     const QMailMessagePart::Location location(attachmentLocation);
+    QMailAccountId accountId = message.parentAccountId();
+    QString attachmentDownloadFolder = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation) + "/mail_attachments/"
+            + QString::number(accountId.toULongLong()) +  "/" + attachmentLocation;
+
     if (message.contains(location)) {
         const QMailMessagePart attachmentPart = message.partAt(location);
         QString attachmentPath = attachmentDownloadFolder + "/" + attachmentPart.displayName();
@@ -1272,12 +1275,12 @@ void EmailAgent::saveAttachmentToDownloads(const QMailMessageId messageId, const
                 emit attachmentUrlChanged(attachmentLocation, path);
                 updateAttachmentDowloadStatus(attachmentLocation, Downloaded);
             } else {
-                qCDebug(lcDebug) << "ERROR: Failed to save attachment file to location " << attachmentDownloadFolder;
+                qCDebug(lcGeneral) << "ERROR: Failed to save attachment file to location " << attachmentDownloadFolder;
                 updateAttachmentDowloadStatus(attachmentLocation, FailedToSave);
             }
         }
     } else {
-        qCDebug(lcDebug) << "ERROR: Can't save attachment, location not found " << attachmentLocation;
+        qCDebug(lcGeneral) << "ERROR: Can't save attachment, location not found " << attachmentLocation;
     }
 }
 
@@ -1298,7 +1301,7 @@ void EmailAgent::updateAttachmentDowloadStatus(const QString &attachmentLocation
         emit attachmentDownloadStatusChanged(attachmentLocation, status);
     } else {
         updateAttachmentDowloadStatus(attachmentLocation, Failed);
-        qCDebug(lcDebug) << "ERROR: Can't update attachment download status for items outside of the download queue, part location: "
+        qCDebug(lcGeneral) << "ERROR: Can't update attachment download status for items outside of the download queue, part location: "
                          << attachmentLocation;
     }
 }


### PR DESCRIPTION
Some accounts might want to clean all data existent on device upon removal,
to facilitate that we save temporary attachments inside a separated folder per
account.