### PR TITLE
[nemo-qml-plugin-email] Improvements to folderListModel. Contributes JB#5528, JB#14094

### DIFF
--- a/src/folderlistmodel.h
+++ b/src/folderlistmodel.h
@@ -103,9 +103,14 @@ private:
     QMailAccountId m_accountId;
     QList<FolderItem*> m_folderList;
 
+    static bool lessThan(const QMailFolderId &idA, const QMailFolderId &idB);
     FolderStandardType folderTypeFromId(const QMailFolderId &id) const;
+    bool isStandardFolder(const QMailFolderId &id) const;
+    void createAndAddFolderItem(const QModelIndex &idx, const QMailFolderId &mailFolderId,
+                                 FolderStandardType mailFolderType, const QMailMessageKey &folderMessageKey);
     QString localFolderName(const FolderStandardType folderType) const;
     void updateCurrentFolderIndex();
+    void addFolderAndChildren(const QMailFolderId &folderId, QMailMessageKey messageKey, QList<QMailFolderId> &originalList);
     void resetModel();
 };
 


### PR DESCRIPTION
- Standard folders at top with respective children’s
- Sort folders correctly under respective parent, use case insensitive sorting
